### PR TITLE
feat: add WithIsComplete predicate for multiline submit control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Multiline submit predicate (`WithIsComplete`)**: In multiline mode, an embedding app can supply a predicate that decides whether Enter submits the buffer or inserts a newline to keep editing. When it returns false, the input is treated as incomplete, so apps can buffer multi-line input (for example SQL until a trailing `;`). Backslash continuation and bracketed paste are unaffected; with no predicate or with multiline off, Enter always submits.
+
 ### Fixed
 - **Bracketed paste multiline handling ([04b4805](https://github.com/nao1215/prompt/commit/04b4805))**: Preserve pasted newlines and trailing backslashes in multiline prompts without changing manual backslash continuation behavior
 

--- a/prompt.go
+++ b/prompt.go
@@ -243,6 +243,7 @@ type Config struct {
 	KeyMap        *KeyMap                     // Key bindings (nil for default)
 	Theme         *ColorScheme                // Alias for ColorScheme for compatibility
 	Multiline     bool                        // Enable multiline input mode
+	IsComplete    func(input string) bool     // Decides whether Enter submits in multiline mode (nil = always submit)
 }
 
 // Option represents a configuration option for prompt
@@ -334,6 +335,19 @@ func WithTheme(theme *ColorScheme) Option {
 func WithMultiline(multiline bool) Option {
 	return func(c *Config) {
 		c.Multiline = multiline
+	}
+}
+
+// WithIsComplete sets a predicate that decides, in multiline mode, whether
+// pressing Enter submits the buffer or inserts a newline. The predicate receives
+// the whole buffer and returns true when the input is a complete statement ready
+// to run; when false, Enter inserts a newline so an embedding app can buffer
+// multi-line input (for example SQL until a trailing ";"). A trailing backslash
+// and bracketed paste still force a newline regardless of the predicate. When nil
+// (default) or when multiline mode is off, Enter always submits.
+func WithIsComplete(isComplete func(input string) bool) Option {
+	return func(c *Config) {
+		c.IsComplete = isComplete
 	}
 }
 
@@ -639,6 +653,11 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 					p.insertRune('\n')
 					suggestions = nil
 				} else if p.isShiftEnter() {
+					p.insertRune('\n')
+					suggestions = nil
+				} else if p.config.Multiline && p.config.IsComplete != nil && !p.config.IsComplete(string(p.buffer)) {
+					// The app reports the statement is incomplete, so keep editing on a
+					// new line instead of submitting (e.g. SQL buffered until ";").
 					p.insertRune('\n')
 					suggestions = nil
 				} else {

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -110,6 +110,39 @@ func TestPromptWithMockTerminal(t *testing.T) {
 			expected: "",
 			config:   Config{Prefix: "$ "},
 		},
+		{
+			// IsComplete reports incomplete until a trailing ";", so the bare
+			// newlines buffer into one statement instead of submitting per line.
+			name:     "multiline buffers until IsComplete returns true",
+			input:    "SELECT 1\nUNION ALL\nSELECT 2;\n",
+			expected: "SELECT 1\nUNION ALL\nSELECT 2;",
+			config: Config{
+				Prefix:     "$ ",
+				Multiline:  true,
+				IsComplete: func(in string) bool { return strings.HasSuffix(strings.TrimSpace(in), ";") },
+			},
+		},
+		{
+			// A statement already terminated with ";" submits on the first Enter.
+			name:     "complete statement submits immediately",
+			input:    "SELECT 1;\n",
+			expected: "SELECT 1;",
+			config: Config{
+				Prefix:     "$ ",
+				Multiline:  true,
+				IsComplete: func(in string) bool { return strings.HasSuffix(strings.TrimSpace(in), ";") },
+			},
+		},
+		{
+			// Without multiline mode the predicate is ignored and Enter submits.
+			name:     "IsComplete ignored when multiline is off",
+			input:    "SELECT 1\n",
+			expected: "SELECT 1",
+			config: Config{
+				Prefix:     "$ ",
+				IsComplete: func(in string) bool { return strings.HasSuffix(strings.TrimSpace(in), ";") },
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

In multiline mode a bare Enter always submitted the buffer, so an embedding app could not buffer an incomplete multi-line statement; only a trailing backslash or bracketed paste kept editing on a new line. This adds an opt-in predicate so the app decides when a statement is complete.

## Changes

- `prompt.go`: add `Config.IsComplete func(input string) bool` and the `WithIsComplete` option. In the Enter handler, when multiline mode is on and the predicate is set and reports the buffer is incomplete, insert a newline instead of submitting.
- `prompt_test.go`: extend the mock-terminal table test with cases for buffering until the predicate returns true, immediate submit of a complete statement, and the predicate being ignored when multiline is off.
- `CHANGELOG.md`: add an Added entry under Unreleased.

## Design Decisions

The predicate receives the whole buffer and returns true when the input is ready to run. This keeps the library SQL-agnostic: the completeness rule (for example, a trailing `;`) lives in the embedding app. Backslash continuation and bracketed paste are evaluated first and are unaffected. The predicate is consulted only in multiline mode, since inserting a newline only renders correctly there; with no predicate or multiline off, Enter always submits, so existing callers are unchanged.