### PR TITLE
feat: add WithWordEscape for escaped word boundaries in completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Escaped word boundaries for completion (`WithWordEscape`)**: An embedding app can opt into treating backslash-escaped whitespace as part of the word before the cursor, so a shell-style path like `my\ data.csv` completes and is accepted as one word instead of breaking at the escaped space. The new `Document.GetWordBeforeCursorEscaped` exposes the same boundary rule. Off by default, so existing word boundaries are unchanged.
+
 ## [0.0.6] - 2026-06-28
 
 ### Added

--- a/completion_escape_test.go
+++ b/completion_escape_test.go
@@ -1,0 +1,91 @@
+package prompt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetWordBeforeCursorEscaped(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{
+			name: "an unescaped space ends the word",
+			text: ".import my data",
+			want: "data",
+		},
+		{
+			name: "a backslash-escaped space keeps the word together",
+			text: `.import my\ dir/in`,
+			want: `my\ dir/in`,
+		},
+		{
+			name: "a trailing escaped space stays part of the word",
+			text: `.import my\ `,
+			want: `my\ `,
+		},
+		{
+			name: "a trailing unescaped space yields an empty word",
+			text: ".import data ",
+			want: "",
+		},
+		{
+			name: "a doubled backslash does not escape the following space",
+			text: `a\\ b`,
+			want: "b",
+		},
+		{
+			name: "an escaped tab keeps the word together",
+			text: "a\\\tb",
+			want: "a\\\tb",
+		},
+		{
+			name: "empty input yields an empty word",
+			text: "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Document{Text: tt.text, CursorPosition: len(tt.text)}
+			assert.Equal(t, tt.want, d.GetWordBeforeCursorEscaped())
+		})
+	}
+}
+
+func TestAcceptSuggestion_WordEscape(t *testing.T) {
+	t.Run("completes a nested space-containing path as a single escaped argument", func(t *testing.T) {
+		p := &Prompt{
+			buffer: []rune(`.import my\ dir/in`),
+			cursor: len(`.import my\ dir/in`),
+			config: Config{WordEscape: true},
+		}
+
+		p.acceptSuggestion(Suggestion{Text: `my\ dir/inner\ file.csv`})
+
+		assert.Equal(t, `.import my\ dir/inner\ file.csv`, string(p.buffer))
+	})
+
+	t.Run("without WordEscape a space splits the word and the suffix logic does not apply", func(t *testing.T) {
+		// Default behavior is unchanged: the current word is only "in", so the
+		// escaped suggestion is not a prefix of it and gets appended instead.
+		p := &Prompt{
+			buffer: []rune(`.import my\ dir/in`),
+			cursor: len(`.import my\ dir/in`),
+		}
+
+		p.acceptSuggestion(Suggestion{Text: `my\ dir/inner\ file.csv`})
+
+		assert.NotEqual(t, `.import my\ dir/inner\ file.csv`, string(p.buffer))
+	})
+}
+
+func TestWithWordEscape(t *testing.T) {
+	c := &Config{}
+	WithWordEscape()(c)
+	assert.True(t, c.WordEscape)
+}

--- a/prompt.go
+++ b/prompt.go
@@ -244,6 +244,7 @@ type Config struct {
 	Theme         *ColorScheme                // Alias for ColorScheme for compatibility
 	Multiline     bool                        // Enable multiline input mode
 	IsComplete    func(input string) bool     // Decides whether Enter submits in multiline mode (nil = always submit)
+	WordEscape    bool                        // Treat backslash-escaped whitespace as part of a word during completion
 }
 
 // Option represents a configuration option for prompt
@@ -351,6 +352,18 @@ func WithIsComplete(isComplete func(input string) bool) Option {
 	}
 }
 
+// WithWordEscape makes completion treat backslash-escaped whitespace as part of
+// the word before the cursor. A shell-style path like "my\ data.csv" is then
+// completed and accepted as one word instead of breaking at the escaped space.
+// Enable it when the embedding app accepts escaped paths (for example a SQL shell
+// whose .import command honors backslash escapes). Off by default; default word
+// boundaries are unchanged.
+func WithWordEscape() Option {
+	return func(c *Config) {
+		c.WordEscape = true
+	}
+}
+
 // Suggestion represents a completion suggestion.
 type Suggestion struct {
 	Text        string // The text to complete
@@ -402,6 +415,49 @@ func (d *Document) GetWordBeforeCursor() string {
 	start++ // Move to the first character of the word
 
 	return text[start:]
+}
+
+// GetWordBeforeCursorEscaped is like GetWordBeforeCursor but treats whitespace
+// that is backslash-escaped as part of the word, so a shell-style path such as
+// "my\ data.csv" counts as a single word rather than two. A whitespace character
+// is a word boundary only when an even number of backslashes precede it. The
+// prompt uses it for completion when WithWordEscape is set.
+func (d *Document) GetWordBeforeCursorEscaped() string {
+	text := d.TextBeforeCursor()
+	if len(text) == 0 {
+		return ""
+	}
+
+	runes := []rune(text)
+	last := len(runes) - 1
+	if isWordSeparator(runes[last]) && !isEscaped(runes, last) {
+		return ""
+	}
+
+	start := 0
+	for i := last; i >= 0; i-- {
+		if isWordSeparator(runes[i]) && !isEscaped(runes, i) {
+			start = i + 1
+			break
+		}
+	}
+	return string(runes[start:])
+}
+
+// isWordSeparator reports whether r ends a word for completion purposes. It
+// matches the separators GetWordBeforeCursor recognizes.
+func isWordSeparator(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n'
+}
+
+// isEscaped reports whether the rune at index i is escaped, i.e. preceded by an
+// odd number of backslashes.
+func isEscaped(runes []rune, i int) bool {
+	backslashes := 0
+	for j := i - 1; j >= 0 && runes[j] == '\\'; j-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
 }
 
 // CurrentLine returns the current line
@@ -817,7 +873,7 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 					suggestionOffset = 0 // Reset scroll position
 
 					// Smart matching: filter suggestions based on current input
-					currentWord := doc.GetWordBeforeCursor()
+					currentWord := p.completionWord(doc)
 					if currentWord != "" {
 						// Filter suggestions to only show those that match the current input
 						filteredSuggestions := make([]Suggestion, 0)
@@ -952,6 +1008,16 @@ func (p *Prompt) setBuffer(text string) {
 	p.cursor = len(p.buffer)
 }
 
+// completionWord returns the word before the cursor used for completion matching
+// and acceptance. It honors backslash-escaped whitespace when WithWordEscape is
+// set so space-containing paths complete as one word.
+func (p *Prompt) completionWord(doc Document) string {
+	if p.config.WordEscape {
+		return doc.GetWordBeforeCursorEscaped()
+	}
+	return doc.GetWordBeforeCursor()
+}
+
 func (p *Prompt) acceptSuggestion(suggestion Suggestion) {
 	// Get current document state for context
 	doc := Document{
@@ -961,7 +1027,7 @@ func (p *Prompt) acceptSuggestion(suggestion Suggestion) {
 
 	// Determine how to apply the suggestion based on context
 	beforeCursor := doc.TextBeforeCursor()
-	currentWord := doc.GetWordBeforeCursor()
+	currentWord := p.completionWord(doc)
 
 	if currentWord == "" {
 		// Cursor is at space or beginning, just insert the suggestion


### PR DESCRIPTION
## Summary

Completion split the word before the cursor at every literal space, so a shell-style path containing an escaped space (for example `my\ dir/`) could not be filtered or accepted as one word. This blocked an embedding app (sqly) from completing files inside directories whose names contain spaces. This adds an opt-in `WithWordEscape` so completion treats backslash-escaped whitespace as part of the word.

## Changes

- `prompt.go`: add `Config.WordEscape` and the `WithWordEscape` option; add `Document.GetWordBeforeCursorEscaped`, which treats whitespace as a word boundary only when an even number of backslashes precede it; route completion filtering and acceptance through a new `completionWord` helper that uses the escaped variant when the option is set.
- `completion_escape_test.go`: unit tests for `GetWordBeforeCursorEscaped` boundary rules, the escaped accept path, and the option setter.
- `CHANGELOG.md`: note the addition under Unreleased.

## Design Decisions

The behavior is opt-in and off by default, so the word boundaries used for navigation and for apps that do not escape paths stay exactly as before. The escaped variant is exposed as a public `Document` method so it is independently testable and usable, and the accept and filter paths share one `completionWord` helper to keep them consistent. A whitespace is considered escaped only when preceded by an odd number of backslashes, so a doubled backslash (`a\\ b`) correctly ends the word.

## Limitations

Only space, tab, and newline are recognized as separators, matching `GetWordBeforeCursor`. Carriage return is not treated as a separator, consistent with the existing method.