### PR TITLE
feat: add ActionClearScreen bound to Ctrl+L

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Clear-screen action (`ActionClearScreen`)**: A new key action clears the terminal screen and scrollback and redraws the prompt at the top with the current input preserved. The default key map binds it to Ctrl+L, matching the typical shell shortcut.
+
 ## [0.0.7] - 2026-06-28
 
 ### Added

--- a/prompt.go
+++ b/prompt.go
@@ -74,6 +74,9 @@ const (
 	ActionNewLine
 	ActionPasteStart
 	ActionPasteEnd
+	// ActionClearScreen clears the terminal screen and redraws the prompt with
+	// the current input preserved, like Ctrl+L in a typical shell.
+	ActionClearScreen
 )
 
 const (
@@ -102,6 +105,7 @@ type KeyMap struct {
 //   - Ctrl+U: Delete entire line
 //   - Ctrl+W: Delete word backwards
 //   - Ctrl+R: Reverse history search
+//   - Ctrl+L: Clear the screen
 //   - Tab: Auto-completion
 //   - Backspace: Delete character backwards
 //   - Arrow keys: Navigate history and move cursor
@@ -135,6 +139,7 @@ func NewDefaultKeyMap() *KeyMap {
 	km.bindings['\x15'] = ActionDeleteLine     // Ctrl+U
 	km.bindings['\x17'] = ActionDeleteWordBack // Ctrl+W
 	km.bindings['\x12'] = ActionHistorySearch  // Ctrl+R
+	km.bindings['\x0C'] = ActionClearScreen    // Ctrl+L
 	km.bindings['\t'] = ActionComplete
 	km.bindings['\x7f'] = ActionDeleteChar // Backspace
 	km.bindings['\b'] = ActionDeleteChar   // Backspace
@@ -926,6 +931,12 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 
 		case ActionPasteEnd:
 			inPaste = false
+
+		case ActionClearScreen:
+			// Clear the whole screen and redraw the prompt at the top with the
+			// current input preserved. The trailing render below repaints it.
+			p.renderer.clearScreen()
+			suggestions = nil
 
 		default:
 			// Handle regular character input

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -2415,6 +2415,15 @@ func TestNewDefaultKeyMapAdvanced(t *testing.T) {
 	}
 }
 
+func TestDefaultKeyMapBindsClearScreen(t *testing.T) {
+	t.Parallel()
+
+	km := NewDefaultKeyMap()
+	if got := km.GetAction('\x0C'); got != ActionClearScreen {
+		t.Errorf("Ctrl+L action = %v, want ActionClearScreen", got)
+	}
+}
+
 func TestKeyMapBindAdvanced(t *testing.T) {
 	t.Parallel()
 

--- a/renderer.go
+++ b/renderer.go
@@ -268,6 +268,15 @@ func (r *renderer) renderSuggestionsWithOffset(_, _ string, _ int, suggestions [
 }
 
 // clearPreviousLines clears the previously rendered lines.
+// clearScreen clears the entire terminal screen and scrollback and homes the
+// cursor, then resets the line-tracking state so the next render draws the
+// prompt at the top. It implements the Ctrl+L clear-screen behavior.
+func (r *renderer) clearScreen() {
+	fmt.Fprint(r.output, "\x1b[H\x1b[2J\x1b[3J")
+	r.lastLines = 1
+	r.suggestionsActive = false
+}
+
 func (r *renderer) clearPreviousLines() {
 	if r.lastLines <= 1 {
 		// Just clear the current line

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -51,6 +51,30 @@ func TestRendererRender(t *testing.T) {
 	}
 }
 
+func TestRendererClearScreen(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	renderer := newRenderer(&output, ThemeDefault, nil)
+	renderer.lastLines = 5 // simulate prior multi-line render
+
+	renderer.clearScreen()
+
+	result := output.String()
+	if !strings.Contains(result, "\x1b[2J") {
+		t.Errorf("clearScreen output = %q, want it to contain the clear-screen escape", result)
+	}
+	if !strings.Contains(result, "\x1b[H") {
+		t.Errorf("clearScreen output = %q, want it to home the cursor", result)
+	}
+	if renderer.lastLines != 1 {
+		t.Errorf("lastLines = %d after clearScreen, want 1", renderer.lastLines)
+	}
+	if renderer.suggestionsActive {
+		t.Error("suggestionsActive should be reset to false after clearScreen")
+	}
+}
+
 func TestRendererRenderWithSuggestions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds a clear-screen key action so embedding apps can offer the typical Ctrl+L shortcut.

`ActionClearScreen` clears the terminal screen and scrollback and redraws the prompt at the top with the current input preserved. The default key map binds it to Ctrl+L, and the renderer resets its line tracking (`lastLines`) so the redraw starts at the top.

## Tests

- `TestDefaultKeyMapBindsClearScreen` asserts Ctrl+L maps to `ActionClearScreen`.
- `TestRendererClearScreen` asserts the clear/home escapes are emitted and the renderer state is reset.