### PR TITLE
fix(prompt): keep raw mode across Run calls to stop input loss between lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Persistent raw mode (`WithPersistentRawMode`) ([#10](https://github.com/nao1215/prompt/issues/10))**: An embedding REPL can keep the terminal in raw mode across consecutive `Run` calls instead of re-acquiring it on every call. Raw mode is entered once on the first `Run` and restored once — by `Close`, on interrupt (Ctrl+C), or on EOF. Off by default, so the classic single-shot usage keeps cooked-mode output after each `Run`.
+
+### Fixed
+- **Interactive input lost between lines ([#10](https://github.com/nao1215/prompt/issues/10))**: A REPL that calls `Run` once per line toggled the terminal between raw and cooked around every command. Input a fast or automated driver (a pipe or pseudo-terminal) sent right after a re-rendered prompt could be dropped in the mode-switch window, making scripted sessions hang intermittently. `WithPersistentRawMode` removes that window; `enterRawMode`/`exitRawMode` are now idempotent so raw mode is acquired and released exactly once per session.
+
 ## [0.0.8] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -283,6 +283,42 @@ p, err := prompt.New("sql> ",
 )
 ```
 
+### Persistent raw mode (REPL loops)
+
+A REPL that calls `Run` once per line normally enters raw mode at the start of
+each call and restores it when the call returns. Between one line's restore and
+the next line's re-acquisition the read loop is not consuming input, so bytes that
+a fast or automated driver (a pipe or pseudo-terminal) sends right after the
+prompt is re-rendered can be lost, making scripted sessions hang intermittently.
+
+`WithPersistentRawMode` keeps the terminal in raw mode across consecutive `Run`
+calls, closing that window and making input deterministic regardless of timing or
+load. Raw mode is acquired once on the first `Run` and released once — by `Close`,
+on interrupt (Ctrl+C), or when input reaches EOF. Because the terminal stays in
+raw mode between calls, print your own output between prompts with `\r\n` rather
+than `\n`.
+
+```go
+p, err := prompt.New("$ ",
+    prompt.WithPersistentRawMode(),
+)
+if err != nil {
+    log.Fatal(err)
+}
+defer p.Close()
+
+for {
+    line, err := p.Run()
+    if errors.Is(err, prompt.ErrEOF) || errors.Is(err, prompt.ErrInterrupted) {
+        break
+    }
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("you typed: %s\r\n", line) // note the \r\n
+}
+```
+
 ## Key bindings
 
 | Key | Action |

--- a/mock.go
+++ b/mock.go
@@ -21,6 +21,8 @@ type mockTerminal struct {
 	inputPos     int    // Current position in the input sequence
 	rawMode      bool   // Track raw mode state for test verification
 	terminalSize [2]int // Fixed terminal dimensions [width, height]
+	setRawCount  int    // Number of SetRaw calls, for verifying raw mode is entered once per session
+	restoreCount int    // Number of Restore calls, for verifying restoration happens
 }
 
 func newMockTerminal(input string) *mockTerminal {
@@ -34,11 +36,13 @@ func newMockTerminal(input string) *mockTerminal {
 
 func (m *mockTerminal) SetRaw() error {
 	m.rawMode = true
+	m.setRawCount++
 	return nil
 }
 
 func (m *mockTerminal) Restore() error {
 	m.rawMode = false
+	m.restoreCount++
 	return nil
 }
 

--- a/prompt.go
+++ b/prompt.go
@@ -38,6 +38,7 @@ type Prompt struct {
 	renderer       *renderer
 	terminal       terminalInterface
 	keyMap         *KeyMap
+	rawActive      bool // Whether the terminal is currently in raw mode
 }
 
 // KeyBinding represents a keyboard shortcut mapping
@@ -250,6 +251,10 @@ type Config struct {
 	Multiline     bool                        // Enable multiline input mode
 	IsComplete    func(input string) bool     // Decides whether Enter submits in multiline mode (nil = always submit)
 	WordEscape    bool                        // Treat backslash-escaped whitespace as part of a word during completion
+	// PersistentRawMode keeps the terminal in raw mode across consecutive Run
+	// calls instead of re-acquiring it on every call. See WithPersistentRawMode
+	// for the rationale and caveats.
+	PersistentRawMode bool
 }
 
 // Option represents a configuration option for prompt
@@ -354,6 +359,30 @@ func WithMultiline(multiline bool) Option {
 func WithIsComplete(isComplete func(input string) bool) Option {
 	return func(c *Config) {
 		c.IsComplete = isComplete
+	}
+}
+
+// WithPersistentRawMode keeps the terminal in raw mode across consecutive Run
+// (RunWithContext) calls instead of entering raw mode at the start of every call
+// and restoring it when the call returns.
+//
+// A REPL that calls Run once per line otherwise toggles the terminal between raw
+// and cooked around every command. Between one line's restore and the next line's
+// re-acquisition the read loop is not consuming input, so bytes that a fast or
+// automated driver (a pipe or pseudo-terminal) sends right after the prompt is
+// re-rendered can be lost. Entering raw mode once for the whole session closes
+// that window and makes input handling deterministic regardless of timing or
+// machine load.
+//
+// When enabled, raw mode is acquired on the first Run call and released once, by
+// Close, on interrupt (Ctrl+C), or when input reaches EOF. Because the terminal
+// stays in raw mode between calls, an embedding application that prints its own
+// output between prompts must terminate lines with "\r\n" rather than "\n". It is
+// off by default so the classic single-shot usage keeps cooked-mode output after
+// each Run.
+func WithPersistentRawMode() Option {
+	return func(c *Config) {
+		c.PersistentRawMode = true
 	}
 }
 
@@ -646,14 +675,17 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("failed to enter raw mode: %w", err)
 	}
 
-	restored := false
 	defer func() {
-		// Only restore if not already restored (prevents double restoration)
-		if !restored {
-			if err := p.exitRawMode(); err != nil {
-				// Log error but don't return it as we're in defer
-				fmt.Fprintf(os.Stderr, "Warning: failed to exit raw mode: %v\n", err)
-			}
+		// In persistent mode the terminal stays in raw mode across calls; it is
+		// restored by Close, on interrupt, or on EOF instead of per call. In the
+		// default mode restore on every return. exitRawMode is idempotent, so the
+		// interrupt and EOF paths that restore early make this a no-op.
+		if p.config.PersistentRawMode {
+			return
+		}
+		if err := p.exitRawMode(); err != nil {
+			// Log error but don't return it as we're in defer
+			fmt.Fprintf(os.Stderr, "Warning: failed to exit raw mode: %v\n", err)
 		}
 	}()
 
@@ -681,6 +713,9 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 		r, err := p.readRune()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
+				// Input reached EOF; the session is over, so restore the terminal
+				// even in persistent mode (the deferred cleanup skips it there).
+				p.restoreOnExit()
 				return "", ErrEOF
 			}
 			return "", fmt.Errorf("failed to read input: %w", err)
@@ -727,18 +762,16 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 						p.addToHistory(result)
 					}
 					fmt.Fprint(p.output, "\r\n")
-					// Terminal will be restored by defer, no need to mark as restored here
+					// The deferred cleanup restores the terminal in the default
+					// mode; in persistent mode it is kept for the next Run.
 					return result, nil
 				}
 			}
 
 		case ActionCancel:
-			// Ensure terminal state is properly restored before returning
-			if err := p.exitRawMode(); err != nil {
-				// Log warning but continue with interrupt handling
-				fmt.Fprintf(os.Stderr, "Warning: failed to restore terminal state: %v\n", err)
-			}
-			restored = true // Mark as restored to prevent double restoration in defer
+			// Ensure terminal state is properly restored before returning. The
+			// interrupt ends the session, so restore even in persistent mode.
+			p.restoreOnExit()
 			fmt.Fprint(p.output, "^C\r\n")
 			return "", ErrInterrupted
 
@@ -951,6 +984,9 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 				historyIndex = len(p.history) // Reset history position
 			} else if r == '\x04' { // Ctrl+D (EOF)
 				if len(p.buffer) == 0 {
+					// Ctrl+D on an empty buffer ends the session; restore the
+					// terminal even in persistent mode before returning.
+					p.restoreOnExit()
 					return "", io.EOF
 				}
 			}
@@ -980,6 +1016,12 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 //	// Use the prompt...
 //	result, err := p.Run()
 func (p *Prompt) Close() error {
+	// Restore raw mode if a persistent session (WithPersistentRawMode) left the
+	// terminal in raw mode. Idempotent, so it is a no-op in the default mode.
+	if err := p.exitRawMode(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to exit raw mode: %v\n", err)
+	}
+
 	// Restore cursor visibility before closing
 	if p.output != nil {
 		fmt.Fprint(p.output, "\x1b[?25h") // Show cursor
@@ -1621,19 +1663,43 @@ func (p *Prompt) removeTrailingBackslash() {
 	}
 }
 
+// enterRawMode puts the terminal into raw mode and enables bracketed paste. It is
+// idempotent: when the terminal is already in raw mode it does nothing, so a
+// persistent session (see WithPersistentRawMode) acquires raw mode exactly once
+// across many Run calls.
 func (p *Prompt) enterRawMode() error {
+	if p.rawActive {
+		return nil
+	}
 	if err := p.terminal.SetRaw(); err != nil {
 		return err
 	}
+	p.rawActive = true
 	if p.output != nil {
 		if _, err := fmt.Fprint(p.output, bracketedPasteEnableSequence); err != nil {
-			return errors.Join(err, p.terminal.Restore())
+			return errors.Join(err, p.exitRawMode())
 		}
 	}
 	return nil
 }
 
+// restoreOnExit restores the terminal from a return path that ends the session
+// (interrupt or EOF), logging any failure. It is used so a persistent session is
+// restored on those paths even though the deferred per-call cleanup skips restore.
+func (p *Prompt) restoreOnExit() {
+	if err := p.exitRawMode(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to restore terminal state: %v\n", err)
+	}
+}
+
+// exitRawMode disables bracketed paste and restores the original terminal state.
+// It is idempotent: when the terminal is not in raw mode it does nothing, so it is
+// safe to call from multiple cleanup paths (defer, interrupt, EOF, Close).
 func (p *Prompt) exitRawMode() error {
+	if !p.rawActive {
+		return nil
+	}
+	p.rawActive = false
 	var errs []error
 	if p.output != nil {
 		if _, err := fmt.Fprint(p.output, bracketedPasteDisableSequence); err != nil {
@@ -1642,9 +1708,6 @@ func (p *Prompt) exitRawMode() error {
 	}
 	if err := p.terminal.Restore(); err != nil {
 		errs = append(errs, err)
-	}
-	if len(errs) == 0 {
-		return nil
 	}
 	return errors.Join(errs...)
 }

--- a/raw_mode_test.go
+++ b/raw_mode_test.go
@@ -1,0 +1,269 @@
+package prompt
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// newTestPrompt builds a Prompt wired to the given mock terminal and a discard
+// output, ready to drive RunWithContext in tests. The options configure the
+// embedded Config (for example WithPersistentRawMode).
+func newTestPrompt(mock *mockTerminal, options ...Option) *Prompt {
+	config := Config{Prefix: "$ "}
+	for _, option := range options {
+		option(&config)
+	}
+	var output bytes.Buffer
+	return &Prompt{
+		config:   config,
+		terminal: mock,
+		keyMap:   NewDefaultKeyMap(),
+		output:   &output,
+		buffer:   []rune{},
+		cursor:   0,
+		history:  []string{},
+		renderer: newRenderer(&output, ThemeDefault, mock),
+	}
+}
+
+// TestConsecutiveRunNoInputLost feeds a REPL-style input sequence through
+// consecutive Run calls sharing one terminal and asserts every line is consumed,
+// including the rune delivered right at the render-to-read boundary of the second
+// call. This pins the "no input dropped between consecutive Run calls" contract.
+func TestConsecutiveRunNoInputLost(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockTerminal("first\rsecond\rthird\r")
+	p := newTestPrompt(mock)
+
+	want := []string{"first", "second", "third"}
+	for i, expected := range want {
+		got, err := p.RunWithContext(context.Background())
+		if err != nil {
+			t.Fatalf("Run %d returned error: %v", i, err)
+		}
+		if got != expected {
+			t.Errorf("Run %d = %q, want %q", i, got, expected)
+		}
+	}
+}
+
+// TestInputAvailableBeforeReadIsConsumed makes input available before the read
+// loop starts (the mock is pre-loaded with the whole line, which is present the
+// moment render finishes) and asserts it is still read. This pins the "no input
+// dropped between render and read" contract.
+func TestInputAvailableBeforeReadIsConsumed(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockTerminal("ready\r")
+	p := newTestPrompt(mock)
+
+	got, err := p.RunWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got != "ready" {
+		t.Errorf("Run = %q, want %q", got, "ready")
+	}
+}
+
+// TestPersistentRawModeEntersOnce asserts that with WithPersistentRawMode the
+// terminal enters raw mode exactly once across a multi-line session (not once per
+// line), that every line is still read, and that Close restores the terminal.
+func TestPersistentRawModeEntersOnce(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockTerminal("alpha\rbeta\rgamma\r")
+	p := newTestPrompt(mock, WithPersistentRawMode())
+
+	want := []string{"alpha", "beta", "gamma"}
+	for i, expected := range want {
+		got, err := p.RunWithContext(context.Background())
+		if err != nil {
+			t.Fatalf("Run %d returned error: %v", i, err)
+		}
+		if got != expected {
+			t.Errorf("Run %d = %q, want %q", i, got, expected)
+		}
+	}
+
+	if mock.setRawCount != 1 {
+		t.Errorf("SetRaw called %d times across the session, want 1", mock.setRawCount)
+	}
+	if mock.restoreCount != 0 {
+		t.Errorf("Restore called %d times before Close, want 0 in persistent mode", mock.restoreCount)
+	}
+	if !mock.rawMode {
+		t.Error("terminal should still be in raw mode between persistent Run calls")
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close returned error: %v", err)
+	}
+	if mock.restoreCount != 1 {
+		t.Errorf("Restore called %d times after Close, want 1", mock.restoreCount)
+	}
+	if mock.rawMode {
+		t.Error("terminal should be restored to cooked mode after Close")
+	}
+}
+
+// TestDefaultModeTogglesRawPerCall asserts the default behavior is preserved:
+// raw mode is entered and restored on every Run call, so a two-line session
+// toggles the terminal twice.
+func TestDefaultModeTogglesRawPerCall(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockTerminal("one\rtwo\r")
+	p := newTestPrompt(mock)
+
+	for i := range 2 {
+		if _, err := p.RunWithContext(context.Background()); err != nil {
+			t.Fatalf("Run %d returned error: %v", i, err)
+		}
+	}
+
+	if mock.setRawCount != 2 {
+		t.Errorf("SetRaw called %d times, want 2 (once per call in default mode)", mock.setRawCount)
+	}
+	if mock.restoreCount != 2 {
+		t.Errorf("Restore called %d times, want 2 (once per call in default mode)", mock.restoreCount)
+	}
+	if mock.rawMode {
+		t.Error("terminal should be restored to cooked mode after each default-mode Run")
+	}
+}
+
+// TestPersistentRawModeRestoresOnEOF asserts that when input reaches EOF the
+// terminal is restored even in persistent mode, and Run returns ErrEOF.
+func TestPersistentRawModeRestoresOnEOF(t *testing.T) {
+	t.Parallel()
+
+	// One complete line, then EOF (no trailing submit) on the second Run.
+	mock := newMockTerminal("done\r")
+	p := newTestPrompt(mock, WithPersistentRawMode())
+
+	got, err := p.RunWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("first Run returned error: %v", err)
+	}
+	if got != "done" {
+		t.Errorf("first Run = %q, want %q", got, "done")
+	}
+	if mock.restoreCount != 0 {
+		t.Errorf("Restore called %d times after a normal submit, want 0 in persistent mode", mock.restoreCount)
+	}
+
+	_, err = p.RunWithContext(context.Background())
+	if !errors.Is(err, ErrEOF) {
+		t.Fatalf("second Run error = %v, want ErrEOF", err)
+	}
+	if mock.restoreCount != 1 {
+		t.Errorf("Restore called %d times after EOF, want 1", mock.restoreCount)
+	}
+	if mock.rawMode {
+		t.Error("terminal should be restored to cooked mode after EOF")
+	}
+	if mock.setRawCount != 1 {
+		t.Errorf("SetRaw called %d times, want 1 (entered once before EOF)", mock.setRawCount)
+	}
+}
+
+// TestPersistentRawModeRestoresOnInterrupt asserts Ctrl+C restores the terminal
+// and returns ErrInterrupted even in persistent mode.
+func TestPersistentRawModeRestoresOnInterrupt(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockTerminal("\x03") // Ctrl+C
+	p := newTestPrompt(mock, WithPersistentRawMode())
+
+	_, err := p.RunWithContext(context.Background())
+	if !errors.Is(err, ErrInterrupted) {
+		t.Fatalf("Run error = %v, want ErrInterrupted", err)
+	}
+	if mock.restoreCount != 1 {
+		t.Errorf("Restore called %d times after interrupt, want 1", mock.restoreCount)
+	}
+	if mock.rawMode {
+		t.Error("terminal should be restored to cooked mode after interrupt")
+	}
+}
+
+// TestPersistentRawModeStressManyLines drives many rapid consecutive lines with
+// no inter-line delay and asserts none are lost and raw mode is entered only once,
+// so the race the fix closes cannot silently regress.
+func TestPersistentRawModeStressManyLines(t *testing.T) {
+	t.Parallel()
+
+	const lines = 200
+	var sb strings.Builder
+	for i := range lines {
+		fmt.Fprintf(&sb, "line-%d\r", i)
+	}
+
+	mock := newMockTerminal(sb.String())
+	p := newTestPrompt(mock, WithPersistentRawMode())
+
+	for i := range lines {
+		got, err := p.RunWithContext(context.Background())
+		if err != nil {
+			t.Fatalf("Run %d returned error: %v", i, err)
+		}
+		want := fmt.Sprintf("line-%d", i)
+		if got != want {
+			t.Fatalf("Run %d = %q, want %q (input lost)", i, got, want)
+		}
+	}
+
+	if mock.setRawCount != 1 {
+		t.Errorf("SetRaw called %d times across %d lines, want 1", mock.setRawCount, lines)
+	}
+}
+
+// TestWithPersistentRawModeOption asserts the option flips the config flag and is
+// off by default.
+func TestWithPersistentRawModeOption(t *testing.T) {
+	t.Parallel()
+
+	config := Config{}
+	if config.PersistentRawMode {
+		t.Error("PersistentRawMode should default to false")
+	}
+	WithPersistentRawMode()(&config)
+	if !config.PersistentRawMode {
+		t.Error("WithPersistentRawMode should set PersistentRawMode to true")
+	}
+}
+
+// TestEnterExitRawModeIdempotent asserts the raw mode helpers are idempotent so
+// they can be called from multiple cleanup paths without double toggling.
+func TestEnterExitRawModeIdempotent(t *testing.T) {
+	t.Parallel()
+
+	mock := newMockTerminal("")
+	p := newTestPrompt(mock)
+
+	if err := p.enterRawMode(); err != nil {
+		t.Fatalf("first enterRawMode error: %v", err)
+	}
+	if err := p.enterRawMode(); err != nil {
+		t.Fatalf("second enterRawMode error: %v", err)
+	}
+	if mock.setRawCount != 1 {
+		t.Errorf("SetRaw called %d times, want 1 (idempotent enter)", mock.setRawCount)
+	}
+
+	if err := p.exitRawMode(); err != nil {
+		t.Fatalf("first exitRawMode error: %v", err)
+	}
+	if err := p.exitRawMode(); err != nil {
+		t.Fatalf("second exitRawMode error: %v", err)
+	}
+	if mock.restoreCount != 1 {
+		t.Errorf("Restore called %d times, want 1 (idempotent exit)", mock.restoreCount)
+	}
+}


### PR DESCRIPTION
## Summary

A REPL built on this library that calls `Run` once per line entered and restored raw mode on every call, toggling the terminal between raw and cooked around every command. Input that a fast or automated driver (a pipe or pseudo-terminal) sent right after a re-rendered prompt could be dropped in that mode-switch window, so scripted sessions (for example sqly's atago-based interactive E2E) hung intermittently. This adds an opt-in that keeps the terminal in raw mode for the whole session and closes the window. Closes #10.

## Changes

- `prompt.go`: add `WithPersistentRawMode` option and the `Config.PersistentRawMode` field; when enabled, raw mode is acquired once on the first `Run` and released once — by `Close`, on interrupt (Ctrl+C), or on EOF — instead of per call.
- `prompt.go`: make `enterRawMode`/`exitRawMode` idempotent via a new `Prompt.rawActive` flag so raw mode is toggled exactly once per session and cleanup is safe from every return path; add a `restoreOnExit` helper used by the interrupt and EOF paths, and restore in `Close`.
- `mock.go`: count `SetRaw`/`Restore` calls on `mockTerminal` so tests can assert raw mode is entered once per session and restored on exit.
- `raw_mode_test.go`: new tests covering consecutive `Run` calls with no input lost, input available before the read loop starts, raw mode entered once for a multi-line session, default-mode per-call toggling preserved, restore on EOF and on interrupt, a 200-line stress run, idempotent enter/exit, and the option flag.
- `README.md` / `CHANGELOG.md`: document the new option and the fix.

## Design Decisions

The fix is opt-in and off by default so the classic single-shot usage (`Run` then print a result with `\n` then `Close`) keeps cooked-mode output after each call and is fully backward compatible; only a REPL that opts in keeps raw mode between prompts, and such an app must print its own inter-prompt output with `\r\n`. Making `enterRawMode`/`exitRawMode` idempotent (rather than tracking a per-call `restored` bool) lets the interrupt, EOF, defer, and `Close` paths all call restore without double-toggling the terminal, which also removes the previous `restored` bookkeeping. Restoration still runs on interrupt and EOF even in persistent mode because those paths end the session.

## Limitations

The regression is exercised through the `mockTerminal` seam, which pins the observable contract (raw mode entered once per session, no runes dropped across consecutive `Run` calls); the underlying real-terminal race is timing-dependent and not reproducible deterministically in unit tests. Adoption by embedding apps such as sqly (switching their REPL loop to `WithPersistentRawMode` and `\r\n` output) is a separate follow-up in those repositories.

https://claude.ai/code/session_017gnwF9zFW6RHjDmfzqKZ2G