### PR TITLE
fix: enter raw mode through go-tty so it governs the read handle (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Raw mode applied to the wrong handle on Windows ([#13](https://github.com/nao1215/prompt/issues/13))**: The terminal entered raw mode with `golang.org/x/term.MakeRaw` on `os.Stdin`, but read input through go-tty's own handle (its `/dev/tty` on Unix, `CONIN$` on Windows). On a Windows ConPTY those are different handles, so raw mode never governed the handle reads actually came from, and input delivered right after a prompt was re-rendered could be mishandled instead of buffered — a command could be typed but never executed. Raw mode now goes through go-tty's `Raw`, so it and the read path share one handle. `SetRaw`/`Restore` are also idempotent, so a persistent session enters raw mode once and cleanup paths stay balanced.
+
 ## [0.0.9] - 2026-07-07
 
 ### Added

--- a/terminal.go
+++ b/terminal.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-tty"
-	"golang.org/x/term"
 )
 
 // terminalInterface abstracts terminal operations for testability and cross-platform compatibility.
@@ -42,16 +41,16 @@ type terminalInterface interface {
 //   - Safe size fallbacks: Returns 80x24 if terminal size detection fails
 //   - Color support: Uses go-colorable for Windows ANSI escape sequence processing
 //   - Resource management: Properly closes TTY to prevent file descriptor leaks
-//   - Proper raw mode handling: Uses golang.org/x/term for reliable terminal state management
+//   - Single-handle raw mode: enters raw mode through go-tty so it applies to the
+//     same handle go-tty reads from
 //
 // The terminal properly manages raw mode state to ensure terminal restoration
 // even when interrupted by Ctrl-C or other signals.
 type realTerminal struct {
-	tty           *tty.TTY    // TTY handle from go-tty for cross-platform terminal operations
-	output        io.Writer   // Color-capable output writer (colorable on Windows, stdout elsewhere)
-	closed        bool        // Track if terminal is already closed to prevent double-close panic on Windows
-	stdinFd       int         // File descriptor for stdin for raw mode management
-	originalState *term.State // Original terminal state to restore on exit
+	tty        *tty.TTY     // TTY handle from go-tty for cross-platform terminal operations
+	output     io.Writer    // Color-capable output writer (colorable on Windows, stdout elsewhere)
+	closed     bool         // Track if terminal is already closed to prevent double-close panic on Windows
+	restoreRaw func() error // Restores the pre-raw terminal state; nil when not in raw mode
 }
 
 // newRealTerminal creates a new terminal instance following simplified design
@@ -69,45 +68,41 @@ func newRealTerminal() (*realTerminal, error) {
 		output = colorable.NewColorableStdout()
 	}
 
-	// Get stdin file descriptor for raw mode management
-	stdinFd := int(os.Stdin.Fd())
-
 	return &realTerminal{
-		tty:     t,
-		output:  output,
-		stdinFd: stdinFd,
+		tty:    t,
+		output: output,
 	}, nil
 }
 
+// SetRaw enters raw mode through go-tty. Using go-tty's own Raw (rather than
+// golang.org/x/term.MakeRaw on os.Stdin) applies raw mode to the very handle
+// go-tty reads from — its /dev/tty on Unix, its CONIN$ on Windows. Setting raw
+// mode on os.Stdin while reading from a different handle left the read path
+// ungoverned on a Windows ConPTY, where input delivered right after a prompt was
+// re-rendered could be mishandled instead of buffered. It is idempotent: when
+// already in raw mode it does nothing, so a persistent session enters raw mode
+// once and Restore stays balanced.
 func (t *realTerminal) SetRaw() error {
-	// Always capture current terminal state before entering raw mode
-	// This ensures proper restoration regardless of how many times we enter/exit raw mode
-	if term.IsTerminal(t.stdinFd) {
-		state, err := term.GetState(t.stdinFd)
-		if err != nil {
-			return err
-		}
-		t.originalState = state
-
-		// Use golang.org/x/term to enter raw mode instead of relying solely on go-tty
-		// This gives us better control over terminal state management
-		_, err = term.MakeRaw(t.stdinFd)
-		if err != nil {
-			return err
-		}
+	if t.restoreRaw != nil || t.tty == nil {
+		return nil
 	}
+	restore, err := t.tty.Raw()
+	if err != nil {
+		return err
+	}
+	t.restoreRaw = restore
 	return nil
 }
 
+// Restore returns the terminal to the state captured when SetRaw entered raw
+// mode. It is idempotent: when not in raw mode it does nothing.
 func (t *realTerminal) Restore() error {
-	// Restore original terminal state to fix cursor position and input visibility
-	if t.originalState != nil && term.IsTerminal(t.stdinFd) {
-		err := term.Restore(t.stdinFd, t.originalState)
-		// Reset the state so that SetRaw can capture a fresh baseline next time
-		t.originalState = nil
-		return err
+	if t.restoreRaw == nil {
+		return nil
 	}
-	return nil
+	restore := t.restoreRaw
+	t.restoreRaw = nil
+	return restore()
 }
 
 func (t *realTerminal) Size() (width, height int, err error) {

--- a/terminal_test.go
+++ b/terminal_test.go
@@ -455,6 +455,39 @@ func TestRealTerminalMultipleSetRawRestore(t *testing.T) {
 	}
 }
 
+func TestRealTerminalSetRawWithoutTTY(t *testing.T) {
+	t.Parallel()
+
+	// With no tty, SetRaw is a no-op (nothing to make raw) and must not panic or
+	// leave a restore hook, so a later Restore is also a safe no-op.
+	terminal := &realTerminal{tty: nil}
+
+	if err := terminal.SetRaw(); err != nil {
+		t.Errorf("SetRaw() with nil tty should not error, got: %v", err)
+	}
+	if terminal.restoreRaw != nil {
+		t.Error("SetRaw() with nil tty should not install a restore hook")
+	}
+	if err := terminal.Restore(); err != nil {
+		t.Errorf("Restore() with nil tty should not error, got: %v", err)
+	}
+}
+
+func TestRealTerminalRestoreIdempotentWithoutRaw(t *testing.T) {
+	t.Parallel()
+
+	// Restore before any SetRaw, and a second Restore, must both be safe no-ops so
+	// the interrupt, EOF, defer, and Close cleanup paths can all call it.
+	terminal := &realTerminal{tty: nil}
+
+	if err := terminal.Restore(); err != nil {
+		t.Errorf("first Restore() should be a no-op, got: %v", err)
+	}
+	if err := terminal.Restore(); err != nil {
+		t.Errorf("second Restore() should be a no-op, got: %v", err)
+	}
+}
+
 func TestRealTerminalCloseWithoutTTY(t *testing.T) {
 	// Create terminal with nil tty
 	terminal := &realTerminal{


### PR DESCRIPTION
## Summary

Raw mode was entered with `golang.org/x/term.MakeRaw` on `os.Stdin`, but input is read through go-tty's own handle — its `/dev/tty` on Unix, its `CONIN$` on Windows. On a Windows ConPTY those are different handles, so raw mode never governed the handle reads actually came from; the read path was governed only by go-tty's open-time mode. Input delivered right after a prompt was re-rendered could then be mishandled instead of buffered, leaving a command typed but never executed and the session hanging. This unifies raw mode and reading onto go-tty's single handle. Refs #13.

## Changes

- `terminal.go`: `SetRaw` now calls go-tty's `Raw()` (which sets raw mode on the same handle go-tty reads from) and stores the returned restore hook, instead of `term.MakeRaw(os.Stdin.Fd())` + `term.GetState`/`term.Restore`. `Restore` calls the stored hook. The `golang.org/x/term` dependency is dropped from the raw path, and `stdinFd`/`originalState` are replaced by a single `restoreRaw` field.
- `SetRaw`/`Restore` are idempotent: `SetRaw` is a no-op when already raw (or when there is no tty), and `Restore` is a no-op when not raw, so a persistent session (`WithPersistentRawMode`) enters raw mode once and the interrupt, EOF, defer, and Close cleanup paths all stay balanced.
- `terminal_test.go`: add unit tests for the no-tty and idempotent-Restore guards.

## Design Decisions

go-tty already owns the terminal handle it reads from and exposes `Raw()` that sets and restores raw mode on exactly that handle, so routing raw mode through it removes the dual-fd split at the root rather than papering over it. On Unix `os.Stdin` and go-tty's `/dev/tty` are the same terminal, so behavior there is unchanged; the fix matters on Windows ConPTY, where they are distinct handles. The real-terminal raw path is exercised by the gated `TestRealTerminal*` tests on CI and, end to end, by the downstream sqly interactive pty E2E on Unix; the Windows ConPTY path is validated by re-enabling sqly's ConPTY E2E once this is released.

## Limitations

This addresses the backend half of #13 (raw mode on the wrong handle). The other half — that the prompt is re-rendered before its read loop is active, with no read-readiness signal for a driver to synchronize on — is a separate design change and is not included here.

https://claude.ai/code/session_017gnwF9zFW6RHjDmfzqKZ2G