### PR TITLE
fix: split raw mode by platform, keep Unix on x/term and go-tty only on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Interactive sessions broken on macOS by the v0.0.10 raw-mode change ([#13](https://github.com/nao1215/prompt/issues/13))**: v0.0.10 routed raw mode through go-tty's `Raw` on every platform, which sets raw mode on a `/dev/tty` descriptor go-tty opens itself. On macOS that regressed interactive sessions: the terminal ended up in a state where the first read returned immediately and the prompt exited without accepting input. Raw mode is now split by platform — Unix keeps the proven `golang.org/x/term.MakeRaw` on `os.Stdin` (the pty slave, the same terminal go-tty reads through), and only Windows routes raw mode through go-tty, where its read handle (CONIN$) genuinely differs from `os.Stdin`. This keeps the Windows ConPTY fix while restoring the working Unix path.
+
 ## [0.0.10] - 2026-07-07
 
 ### Fixed

--- a/terminal.go
+++ b/terminal.go
@@ -9,6 +9,12 @@ import (
 	"github.com/mattn/go-tty"
 )
 
+// rawEnter is defined per platform (terminal_unix.go, terminal_windows.go). It
+// puts the terminal into raw mode and returns a function that restores the
+// pre-raw state. When there is nothing to make raw (input is not a terminal, or
+// there is no tty), it returns a nil restore func and a nil error so SetRaw
+// becomes a no-op. See each file for why the platforms differ.
+
 // terminalInterface abstracts terminal operations for testability and cross-platform compatibility.
 //
 // This interface provides a clean abstraction over platform-specific terminal operations,
@@ -41,8 +47,8 @@ type terminalInterface interface {
 //   - Safe size fallbacks: Returns 80x24 if terminal size detection fails
 //   - Color support: Uses go-colorable for Windows ANSI escape sequence processing
 //   - Resource management: Properly closes TTY to prevent file descriptor leaks
-//   - Single-handle raw mode: enters raw mode through go-tty so it applies to the
-//     same handle go-tty reads from
+//   - Raw mode on the read handle: raw mode is applied to whatever handle input is
+//     read from, per platform, so a re-rendered prompt cannot outrun raw mode
 //
 // The terminal properly manages raw mode state to ensure terminal restoration
 // even when interrupted by Ctrl-C or other signals.
@@ -74,19 +80,15 @@ func newRealTerminal() (*realTerminal, error) {
 	}, nil
 }
 
-// SetRaw enters raw mode through go-tty. Using go-tty's own Raw (rather than
-// golang.org/x/term.MakeRaw on os.Stdin) applies raw mode to the very handle
-// go-tty reads from — its /dev/tty on Unix, its CONIN$ on Windows. Setting raw
-// mode on os.Stdin while reading from a different handle left the read path
-// ungoverned on a Windows ConPTY, where input delivered right after a prompt was
-// re-rendered could be mishandled instead of buffered. It is idempotent: when
-// already in raw mode it does nothing, so a persistent session enters raw mode
+// SetRaw enters raw mode via the platform-specific rawEnter, which applies raw
+// mode to the handle input is actually read from. It is idempotent: once a
+// restore hook is held it does nothing, so a persistent session enters raw mode
 // once and Restore stays balanced.
 func (t *realTerminal) SetRaw() error {
-	if t.restoreRaw != nil || t.tty == nil {
+	if t.restoreRaw != nil {
 		return nil
 	}
-	restore, err := t.tty.Raw()
+	restore, err := t.rawEnter()
 	if err != nil {
 		return err
 	}

--- a/terminal_unix.go
+++ b/terminal_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package prompt
+
+import (
+	"os"
+
+	"golang.org/x/term"
+)
+
+// rawEnter puts the terminal into raw mode on Unix by setting raw mode on
+// os.Stdin. Under a pseudo-terminal os.Stdin is the pty slave, and go-tty reads
+// through /dev/tty, which resolves to that same controlling terminal, so raw
+// mode set here governs the read path. This is the path that shipped on Unix
+// before the Windows fix and is kept unchanged: go-tty's own Raw sets raw mode on
+// a separately opened /dev/tty descriptor, which regressed interactive sessions
+// on macOS, so only Windows (where the read handle genuinely differs from
+// os.Stdin) routes raw mode through go-tty.
+//
+// When os.Stdin is not a terminal there is nothing to make raw, so it returns a
+// nil restore func and lets SetRaw stay a no-op.
+func (t *realTerminal) rawEnter() (func() error, error) {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return nil, nil
+	}
+	state, err := term.GetState(fd)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := term.MakeRaw(fd); err != nil {
+		return nil, err
+	}
+	return func() error { return term.Restore(fd, state) }, nil
+}

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package prompt
+
+// rawEnter puts the terminal into raw mode on Windows through go-tty's own Raw.
+// go-tty reads input from a CONIN$ handle it opens itself, which under a ConPTY
+// is a different handle than os.Stdin. Setting raw mode on os.Stdin there left
+// the read handle in cooked mode, so input delivered right after a re-rendered
+// prompt could be line-buffered instead of read immediately, leaving a command
+// typed but never executed and the session hung. Routing raw mode through go-tty
+// applies it to the same handle reads come from.
+//
+// When there is no tty there is nothing to make raw, so it returns a nil restore
+// func and lets SetRaw stay a no-op.
+func (t *realTerminal) rawEnter() (func() error, error) {
+	if t.tty == nil {
+		return nil, nil
+	}
+	return t.tty.Raw()
+}


### PR DESCRIPTION
## Summary

v0.0.10 fixed the Windows ConPTY input-loss bug (#13) by routing raw mode through go-tty's own Raw on every platform, but that regressed interactive sessions on macOS: go-tty's Raw sets raw mode on a /dev/tty descriptor it opens itself, and on macOS the session ended up in a state where the first read returned immediately, so the prompt exited without accepting input. This splits raw mode by platform so the Windows fix stays while the Unix path returns to what worked. Refs #13.

## Changes

- terminal.go: SetRaw now delegates to a platform-specific rawEnter that returns a restore hook; the idempotency guard and Restore are unchanged. The struct no longer hard-codes the go-tty raw path.
- terminal_unix.go (new, non-Windows): rawEnter uses golang.org/x/term.MakeRaw on os.Stdin, the pre-v0.0.10 behavior. Under a pty os.Stdin is the slave and go-tty reads through /dev/tty, the same controlling terminal, so raw mode governs the read path.
- terminal_windows.go (new): rawEnter routes raw mode through go-tty's Raw, because on Windows go-tty reads from a CONIN$ handle that genuinely differs from os.Stdin under a ConPTY.

## Design Decisions

The dual-fd problem only exists where the read handle differs from os.Stdin, which is Windows (CONIN$) — not Unix, where os.Stdin and go-tty's /dev/tty are the same terminal. v0.0.10 over-generalized the fix to all platforms and paid for it on macOS, so the raw path is now the proven x/term one everywhere except Windows. rawEnter returns a nil restore func when input is not a terminal (or there is no tty), so SetRaw stays a no-op and Restore stays balanced. The Unix and Windows paths are verified end to end by the downstream sqly interactive pty E2E, which runs on Linux, macOS, and Windows ConPTY.

## Limitations

Local verification runs on Linux (POSIX pty). macOS and Windows ConPTY are verified by the downstream sqly E2E matrix in CI.

https://claude.ai/code/session_017gnwF9zFW6RHjDmfzqKZ2G