### PR TITLE
feat(prompt): add a continuation prefix for multiline input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Continuation prefix (`WithContinuationPrefix`, `SetContinuationPrefix`)**: A multiline prompt can now draw a marker in front of every line after the first. Without one, a buffer that `WithIsComplete` declined left the cursor on a bare line with nothing in front of it, which is indistinguishable from a hung program — the user could not tell that the prompt was waiting for the rest of a statement. This is the state sqlite3 shows as `   ...> `, psql as `db-# `, and mysql as `    -> `. The prefix is drawn in the prompt's own color, counted when positioning the cursor and when measuring how many terminal rows the input occupies, and never enters the returned input. The default is empty, which preserves the previous appearance.
+- **Continuation prefix (`WithContinuationPrefix`, `SetContinuationPrefix`) (PR [#18](https://github.com/nao1215/prompt/pull/18), [e89e17b](https://github.com/nao1215/prompt/commit/e89e17b))**: A multiline prompt can now draw a marker in front of every line after the first. Without one, a buffer that `WithIsComplete` declined left the cursor on a bare line with nothing in front of it, which is indistinguishable from a hung program — the user could not tell that the prompt was waiting for the rest of a statement. This is the state sqlite3 shows as "   ...> ", psql as "db-# ", and mysql as "    -> ". The prefix is drawn in the prompt's own color, counted when positioning the cursor and when measuring how many terminal rows the input occupies, and never enters the returned input. The default is empty, which preserves the previous appearance.
 
 ## [0.0.11] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Continuation prefix (`WithContinuationPrefix`, `SetContinuationPrefix`)**: A multiline prompt can now draw a marker in front of every line after the first. Without one, a buffer that `WithIsComplete` declined left the cursor on a bare line with nothing in front of it, which is indistinguishable from a hung program — the user could not tell that the prompt was waiting for the rest of a statement. This is the state sqlite3 shows as `   ...> `, psql as `db-# `, and mysql as `    -> `. The prefix is drawn in the prompt's own color, counted when positioning the cursor and when measuring how many terminal rows the input occupies, and never enters the returned input. The default is empty, which preserves the previous appearance.
+
 ## [0.0.11] - 2026-07-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ p, err := prompt.New("sql> ",
 )
 ```
 
-```
+```text
 sql> SELECT id,
  ..> name FROM users;
 ```

--- a/README.md
+++ b/README.md
@@ -283,6 +283,29 @@ p, err := prompt.New("sql> ",
 )
 ```
 
+Pair it with `WithContinuationPrefix` so a buffered line says it is waiting.
+Without one, a statement `IsComplete` declined leaves the cursor on a bare line
+with nothing in front of it, which is indistinguishable from a hung program:
+
+```go
+p, err := prompt.New("sql> ",
+    prompt.WithMultiline(true),
+    prompt.WithIsComplete(isComplete),
+    prompt.WithContinuationPrefix(" ..> "),
+)
+```
+
+```
+sql> SELECT id,
+ ..> name FROM users;
+```
+
+The prefix is drawn in the prompt's color and counted when positioning the cursor
+and measuring how many rows the input occupies, so editing a continuation line
+lands where the character is. It never appears in the returned input. Use
+`SetContinuationPrefix` to change it between calls, as `SetPrefix` does for the
+main prefix.
+
 ### Persistent raw mode (REPL loops)
 
 A REPL that calls `Run` once per line normally enters raw mode at the start of

--- a/example/multiline/main.go
+++ b/example/multiline/main.go
@@ -18,9 +18,12 @@ func main() {
 	fmt.Println("Type 'exit' to quit")
 	fmt.Println()
 
-	// Create prompt for multiline input
+	// Create prompt for multiline input. The continuation prefix marks the lines
+	// that are still being buffered, so a continued entry cannot be mistaken for
+	// a hung program.
 	p, err := prompt.New("multi> ",
 		prompt.WithMultiline(true),
+		prompt.WithContinuationPrefix("  ...> "),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/prompt.go
+++ b/prompt.go
@@ -251,6 +251,9 @@ type Config struct {
 	Multiline     bool                        // Enable multiline input mode
 	IsComplete    func(input string) bool     // Decides whether Enter submits in multiline mode (nil = always submit)
 	WordEscape    bool                        // Treat backslash-escaped whitespace as part of a word during completion
+	// ContinuationPrefix is drawn in front of every line after the first while a
+	// multiline entry is still being typed. See WithContinuationPrefix.
+	ContinuationPrefix string
 	// PersistentRawMode keeps the terminal in raw mode across consecutive Run
 	// calls instead of re-acquiring it on every call. See WithPersistentRawMode
 	// for the rationale and caveats.
@@ -359,6 +362,27 @@ func WithMultiline(multiline bool) Option {
 func WithIsComplete(isComplete func(input string) bool) Option {
 	return func(c *Config) {
 		c.IsComplete = isComplete
+	}
+}
+
+// WithContinuationPrefix sets the string drawn in front of every line after the
+// first while a multiline entry is still being typed.
+//
+// Without one, a buffer that WithIsComplete declined leaves the cursor on a bare
+// line with nothing in front of it, which is indistinguishable from a hung
+// program: the user cannot tell that the prompt is waiting for the rest of a
+// statement. A continuation prefix is how sqlite3 ("   ...> "), psql ("db-# "),
+// and mysql ("    -> ") show the same state.
+//
+// The prefix is drawn in the prompt's own color and is counted when positioning
+// the cursor and when measuring how many terminal rows the input occupies, so
+// editing on a continuation line lands where the character is. It has no effect
+// on the returned input, which never contains it, and none outside multiline
+// mode, where there is only ever one line. The default is empty, which preserves
+// the previous appearance.
+func WithContinuationPrefix(prefix string) Option {
+	return func(c *Config) {
+		c.ContinuationPrefix = prefix
 	}
 }
 
@@ -1182,6 +1206,13 @@ func (p *Prompt) SetPrefix(prefix string) {
 	p.config.Prefix = prefix
 }
 
+// SetContinuationPrefix changes the string drawn in front of every line after
+// the first while a multiline entry is still being typed. See
+// WithContinuationPrefix.
+func (p *Prompt) SetContinuationPrefix(prefix string) {
+	p.config.ContinuationPrefix = prefix
+}
+
 // SetCompleter changes the completion function
 func (p *Prompt) SetCompleter(completer func(Document) []Suggestion) {
 	p.config.Completer = completer
@@ -1713,10 +1744,12 @@ func (p *Prompt) exitRawMode() error {
 }
 
 func (p *Prompt) render() error {
+	p.renderer.setContinuationPrefix(p.config.ContinuationPrefix)
 	return p.renderer.render(p.config.Prefix, string(p.buffer), p.cursor)
 }
 
 func (p *Prompt) renderWithSuggestionsOffset(suggestions []Suggestion, selected int, offset int) error {
+	p.renderer.setContinuationPrefix(p.config.ContinuationPrefix)
 	return p.renderer.renderWithSuggestionsOffset(p.config.Prefix, string(p.buffer), p.cursor, suggestions, selected, offset)
 }
 

--- a/prompt_test.go
+++ b/prompt_test.go
@@ -4171,3 +4171,70 @@ func newForTestingWithConfig(t *testing.T, config Config, mockInput string) *Pro
 
 	return p
 }
+
+func TestContinuationPrefix(t *testing.T) {
+	t.Parallel()
+
+	incomplete := func(in string) bool { return strings.HasSuffix(strings.TrimSpace(in), ";") }
+
+	t.Run("marks buffered lines without entering the result", func(t *testing.T) {
+		t.Parallel()
+
+		p := newForTestingWithConfig(t, Config{
+			Prefix:             "$ ",
+			Multiline:          true,
+			IsComplete:         incomplete,
+			ContinuationPrefix: "...> ",
+		}, "SELECT 1\nUNION ALL\nSELECT 2;\n")
+		defer p.Close()
+
+		var output bytes.Buffer
+		p.output = &output
+		p.renderer = newRenderer(&output, p.config.ColorScheme, p.terminal)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		result, err := p.RunWithContext(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT 1\nUNION ALL\nSELECT 2;", result, "the continuation prefix must not enter the returned input")
+		assert.Contains(t, output.String(), "...> ", "the continuation prefix should have been drawn")
+	})
+
+	t.Run("is absent by default", func(t *testing.T) {
+		t.Parallel()
+
+		p := newForTestingWithConfig(t, Config{
+			Prefix:     "$ ",
+			Multiline:  true,
+			IsComplete: incomplete,
+		}, "SELECT 1\nSELECT 2;\n")
+		defer p.Close()
+
+		var output bytes.Buffer
+		p.output = &output
+		p.renderer = newRenderer(&output, p.config.ColorScheme, p.terminal)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		result, err := p.RunWithContext(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, "SELECT 1\nSELECT 2;", result)
+		assert.NotContains(t, output.String(), "...> ")
+	})
+
+	t.Run("option and setter reach the config", func(t *testing.T) {
+		t.Parallel()
+
+		var cfg Config
+		WithContinuationPrefix("...> ")(&cfg)
+		assert.Equal(t, "...> ", cfg.ContinuationPrefix)
+
+		p := newForTestingWithConfig(t, cfg, "")
+		defer p.Close()
+
+		p.SetContinuationPrefix("  -> ")
+		assert.Equal(t, "  -> ", p.config.ContinuationPrefix)
+	})
+}

--- a/renderer.go
+++ b/renderer.go
@@ -30,6 +30,10 @@ type renderer struct {
 	lastLines         int               // Track number of lines rendered for efficient cleanup
 	suggestionsActive bool              // Track if suggestions are currently displayed
 	terminal          terminalInterface // Terminal interface for getting size information
+	// continuationPrefix is drawn in front of every line after the first, so a
+	// multiline entry shows that the prompt is still collecting input. Empty
+	// (the default) keeps continuation lines flush against the left margin.
+	continuationPrefix string
 }
 
 // newRenderer creates a new renderer with the given output and color scheme.
@@ -41,6 +45,12 @@ func newRenderer(output io.Writer, colorScheme *ColorScheme, terminal terminalIn
 		suggestionsActive: false,
 		terminal:          terminal,
 	}
+}
+
+// setContinuationPrefix sets the string drawn in front of every line after the
+// first. It is applied on the next render.
+func (r *renderer) setContinuationPrefix(prefix string) {
+	r.continuationPrefix = prefix
 }
 
 // render displays the prompt with the current input.
@@ -138,12 +148,17 @@ func (r *renderer) renderLines(prefix, input string) error {
 			}
 		}
 
+		// The first line carries the prompt prefix; the rest carry the
+		// continuation prefix, which is empty unless the caller set one.
+		linePrefix := r.continuationPrefix
 		if lineIndex == 0 {
-			// First line: render prefix
+			linePrefix = prefix
+		}
+		if linePrefix != "" {
 			if _, err := fmt.Fprint(r.output, r.colorScheme.Prefix.ToANSI()); err != nil {
 				return err
 			}
-			if _, err := fmt.Fprint(r.output, prefix); err != nil {
+			if _, err := fmt.Fprint(r.output, linePrefix); err != nil {
 				return err
 			}
 			if _, err := fmt.Fprint(r.output, Reset()); err != nil {
@@ -404,9 +419,11 @@ func (r *renderer) positionCursor(lines []string, cursorLine, cursorCol, prefixL
 			fmt.Fprintf(r.output, "\x1b[%dC", totalCol)
 		}
 	} else {
-		// Continuation lines: just move to cursor column (from line start)
-		if cursorCol > 0 {
-			fmt.Fprintf(r.output, "\x1b[%dC", cursorCol)
+		// Continuation lines: add the continuation prefix, which is empty unless
+		// the caller set one.
+		totalCol := cursorCol + len([]rune(r.continuationPrefix))
+		if totalCol > 0 {
+			fmt.Fprintf(r.output, "\x1b[%dC", totalCol)
 		}
 	}
 }
@@ -442,8 +459,9 @@ func (r *renderer) calculateRenderedLines(prefix, input string) int {
 			// First line includes the actual prefix
 			actualLength = prefixLen + len(lineRunes)
 		} else {
-			// Continuation lines have no prefix, just the line content
-			actualLength = len(lineRunes)
+			// Continuation lines carry the continuation prefix, which is empty
+			// unless the caller set one
+			actualLength = len([]rune(r.continuationPrefix)) + len(lineRunes)
 		}
 
 		// Calculate how many terminal lines this will take

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -938,3 +938,79 @@ func TestRendererLongListScrolling(t *testing.T) {
 		}
 	}
 }
+
+func TestRendererContinuationPrefix(t *testing.T) {
+	t.Parallel()
+
+	t.Run("continuation lines carry the prefix", func(t *testing.T) {
+		t.Parallel()
+
+		var output bytes.Buffer
+		renderer := newRenderer(&output, ThemeDefault, nil)
+		renderer.setContinuationPrefix("...> ")
+
+		if err := renderer.render("$ ", "SELECT id,\nname", 15); err != nil {
+			t.Fatalf("render() error = %v", err)
+		}
+
+		got := output.String()
+		if !strings.Contains(got, "$ ") {
+			t.Errorf("render() lost the first-line prefix: %q", got)
+		}
+		if !strings.Contains(got, "...> ") {
+			t.Errorf("render() did not draw the continuation prefix: %q", got)
+		}
+		if strings.Count(got, "...> ") != 1 {
+			t.Errorf("render() drew the continuation prefix %d times, want 1: %q", strings.Count(got, "...> "), got)
+		}
+	})
+
+	t.Run("no continuation prefix is drawn by default", func(t *testing.T) {
+		t.Parallel()
+
+		var output bytes.Buffer
+		renderer := newRenderer(&output, ThemeDefault, nil)
+
+		if err := renderer.render("$ ", "SELECT id,\nname", 15); err != nil {
+			t.Fatalf("render() error = %v", err)
+		}
+		if strings.Contains(output.String(), "...> ") {
+			t.Errorf("render() drew a continuation prefix without one being set: %q", output.String())
+		}
+	})
+
+	t.Run("single-line input never draws the continuation prefix", func(t *testing.T) {
+		t.Parallel()
+
+		var output bytes.Buffer
+		renderer := newRenderer(&output, ThemeDefault, nil)
+		renderer.setContinuationPrefix("...> ")
+
+		if err := renderer.render("$ ", "SELECT 1;", 9); err != nil {
+			t.Fatalf("render() error = %v", err)
+		}
+		if strings.Contains(output.String(), "...> ") {
+			t.Errorf("render() drew the continuation prefix on a single line: %q", output.String())
+		}
+	})
+
+	t.Run("wrapped-line count accounts for the continuation prefix", func(t *testing.T) {
+		t.Parallel()
+
+		var output bytes.Buffer
+		renderer := newRenderer(&output, ThemeDefault, nil)
+
+		plain := renderer.calculateRenderedLines("$ ", "a\n"+strings.Repeat("b", 78))
+		renderer.setContinuationPrefix("...> ")
+		prefixed := renderer.calculateRenderedLines("$ ", "a\n"+strings.Repeat("b", 78))
+
+		// 78 columns fits one 80-column row alone but not once a 5-column
+		// continuation prefix sits in front of it.
+		if plain != 2 {
+			t.Errorf("calculateRenderedLines() without a continuation prefix = %d, want 2", plain)
+		}
+		if prefixed != 3 {
+			t.Errorf("calculateRenderedLines() with a continuation prefix = %d, want 3", prefixed)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

In multiline mode a buffer that `WithIsComplete` declines leaves the cursor on a bare line with nothing in front of it. That is indistinguishable from a hung program: the user has no way to tell that the prompt is waiting for the rest of a statement rather than stuck. sqlite3 shows `   ...> `, psql shows `db-# `, and mysql shows `    -> ` for exactly this state, and the library had no way to draw one. `WithContinuationPrefix` (and `SetContinuationPrefix`, mirroring `SetPrefix`) adds it.

This came out of driving sqly's REPL over a pty: typing a query without a trailing `;` produced a blank line and a session that looked frozen for thirty seconds until the test killed it.

## Changes

- `prompt.go`: `Config.ContinuationPrefix`, the `WithContinuationPrefix` option, the `SetContinuationPrefix` method, and the two render entry points pushing the value into the renderer so `SetTheme` (which rebuilds the renderer) cannot drop it.
- `renderer.go`: the renderer carries the prefix and draws it on every line after the first, in the prompt's own color. `positionCursor` adds its width on continuation lines, and `calculateRenderedLines` counts it so a wrapped continuation line is measured correctly.
- `renderer_test.go`: `TestRendererContinuationPrefix` covers that the prefix is drawn once per continuation line, that nothing is drawn by default or on single-line input, and that a line wrapping at the terminal edge is counted with the prefix included.
- `prompt_test.go`: `TestContinuationPrefix` runs a full multiline entry through `RunWithContext` and asserts the prefix reaches the output while staying out of the returned string, plus the default-off case and the option/setter plumbing.
- `README.md`, `CHANGELOG.md`, and `example/multiline` document and demonstrate it.

## Design Decisions

The prefix lives on the renderer as state rather than as another parameter on `render`/`renderMainLine`/`renderWithSuggestionsOffset`. Those signatures are called from a few dozen test sites, and the value is per-prompt configuration rather than per-call data, so a field plus a setter keeps the change contained.

The default is the empty string, which renders exactly as before, so existing callers see no change. It is applied unconditionally rather than gated on `Multiline`, because outside multiline mode there is never more than one line for it to appear on.

Width is measured in runes, consistent with how the existing code measures the main prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable continuation prefixes for multiline prompts, displaying a colored marker before each continued line.
  * Continuation prefixes correctly support cursor positioning and terminal layout without affecting submitted input.
  * Prefixes can be configured when creating a prompt or changed while it is running.

* **Documentation**
  * Added guidance and examples for pairing continuation prefixes with multiline completion controls.
  * Updated the multiline example and changelog with usage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->