### PR TITLE
fix(renderer): measure prefix and line widths in terminal cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A wide or zero-width character misplaced the cursor and miscounted wrapped rows ([#19](https://github.com/nao1215/prompt/issues/19))**: Prefix and line widths were counted in runes. A rune is not a terminal cell: `"データ> "` is 5 runes and 8 columns, an emoji is 1 rune and 2 columns, and a combining mark is a rune that occupies none. A CJK or emoji prompt prefix therefore left the cursor several columns from the character it was meant to sit on, and a line that wrapped at the terminal edge was counted as fitting, so the redraw cleared too few rows and left stale text behind. Cursor positioning and the wrapped-row count now measure display cells, including the text before the cursor on its own line, which the multi-line branch had ignored entirely.
+
 ## [0.0.12] - 2026-07-29
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,14 @@ go 1.24.0
 
 require (
 	github.com/mattn/go-colorable v0.1.14
+	github.com/mattn/go-runewidth v0.0.27
 	github.com/mattn/go-tty v0.0.7
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/term v0.35.0
 )
 
 require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,13 @@
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.27 h1:Feg/Oou5zI/wnpgDF6omIU0OokC9GxLC/WRknhVlIR0=
+github.com/mattn/go-runewidth v0.0.27/go.mod h1:3qAiGCV4Koz/yuveO58qUefmUTRm8r0IGEXZ9jeHp/8=
 github.com/mattn/go-tty v0.0.7 h1:KJ486B6qI8+wBO7kQxYgmmEFDaFEE96JMBQ7h400N8Q=
 github.com/mattn/go-tty v0.0.7/go.mod h1:f2i5ZOvXBU/tCABmLmOfzLz9azMo5wdAaElRNnJKr+k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/renderer.go
+++ b/renderer.go
@@ -4,7 +4,18 @@ import (
 	"fmt"
 	"io"
 	"strings"
+
+	"github.com/mattn/go-runewidth"
 )
+
+// displayWidth returns how many terminal cells s occupies. Cursor positioning
+// and line-wrap arithmetic are in cells, not runes: "データ> " is 5 runes and 8
+// columns, an emoji is 1 rune and 2 columns, and a combining mark is a rune that
+// occupies none. Counting runes moved the cursor to the wrong column and
+// miscounted how many rows the input took, which left stale rows on redraw.
+func displayWidth(s string) int {
+	return runewidth.StringWidth(s)
+}
 
 // renderer handles the display of the prompt and suggestions with advanced terminal control.
 //
@@ -119,7 +130,7 @@ func (r *renderer) renderMainLine(prefix, input string, cursor int) error {
 	lines := r.splitIntoLines(input)
 	inputRunes := []rune(input)
 	cursorLine, cursorCol := r.findCursorPosition(inputRunes, cursor)
-	r.positionCursor(lines, cursorLine, cursorCol, len([]rune(prefix)))
+	r.positionCursor(lines, cursorLine, cursorCol, prefix)
 
 	return nil
 }
@@ -381,15 +392,18 @@ func (r *renderer) findCursorPosition(inputRunes []rune, cursor int) (line, col 
 //   - \x1b[<n>A: Move cursor up n lines
 //   - \x1b[<n>C: Move cursor right n characters
 //   - \r: Move cursor to beginning of line
-func (r *renderer) positionCursor(lines []string, cursorLine, cursorCol, prefixLen int) {
+//
+// cursorCol is a rune index within its line; every distance written here is the
+// display width of the text it spans, so a wide or zero-width character lands the
+// cursor on the cell the user sees.
+func (r *renderer) positionCursor(lines []string, cursorLine, cursorCol int, prefix string) {
 	totalLines := len(lines)
 	if totalLines <= 1 {
 		// Single line - move cursor back from end of line
-		lineLen := len([]rune(lines[0]))
-		if cursorCol < lineLen {
-			runesAfterCursor := lineLen - cursorCol
-			if runesAfterCursor > 0 {
-				fmt.Fprintf(r.output, "\x1b[%dD", runesAfterCursor)
+		lineRunes := []rune(lines[0])
+		if cursorCol < len(lineRunes) {
+			if back := displayWidth(string(lineRunes[cursorCol:])); back > 0 {
+				fmt.Fprintf(r.output, "\x1b[%dD", back)
 			}
 		}
 		return
@@ -398,7 +412,7 @@ func (r *renderer) positionCursor(lines []string, cursorLine, cursorCol, prefixL
 	// Multi-line positioning: simple approach
 	// 1. Move up to the target line (if needed)
 	// 2. Move to beginning of that line
-	// 3. Move right to cursor position (no prefix calculation for continuation lines)
+	// 3. Move right by the width of that line's prefix plus the text before the cursor
 
 	// Calculate how many lines to move up from the last line (where cursor currently is)
 	// to the target line (cursorLine)
@@ -411,20 +425,19 @@ func (r *renderer) positionCursor(lines []string, cursorLine, cursorCol, prefixL
 	// Move to beginning of current line
 	fmt.Fprint(r.output, "\r")
 
-	// Simple column positioning
+	// The first line carries the prompt prefix; the rest carry the continuation
+	// prefix, which is empty unless the caller set one.
+	linePrefix := r.continuationPrefix
 	if cursorLine == 0 {
-		// First line: add prefix length
-		totalCol := cursorCol + prefixLen
-		if totalCol > 0 {
-			fmt.Fprintf(r.output, "\x1b[%dC", totalCol)
-		}
-	} else {
-		// Continuation lines: add the continuation prefix, which is empty unless
-		// the caller set one.
-		totalCol := cursorCol + len([]rune(r.continuationPrefix))
-		if totalCol > 0 {
-			fmt.Fprintf(r.output, "\x1b[%dC", totalCol)
-		}
+		linePrefix = prefix
+	}
+	lineRunes := []rune(lines[cursorLine])
+	if cursorCol > len(lineRunes) {
+		cursorCol = len(lineRunes)
+	}
+	totalCol := displayWidth(linePrefix) + displayWidth(string(lineRunes[:cursorCol]))
+	if totalCol > 0 {
+		fmt.Fprintf(r.output, "\x1b[%dC", totalCol)
 	}
 }
 
@@ -448,20 +461,21 @@ func (r *renderer) calculateRenderedLines(prefix, input string) int {
 	lines := strings.Split(input, "\n")
 
 	totalLines := 0
-	prefixLen := len([]rune(prefix))
+	// Widths are in terminal cells: a wide rune fills two of them, so counting
+	// runes reported a line as fitting when it actually wrapped.
+	prefixLen := displayWidth(prefix)
+	continuationLen := displayWidth(r.continuationPrefix)
 
 	for i, line := range lines {
-		lineRunes := []rune(line)
-
 		// Calculate the actual length including prefix/indentation
 		var actualLength int
 		if i == 0 {
 			// First line includes the actual prefix
-			actualLength = prefixLen + len(lineRunes)
+			actualLength = prefixLen + displayWidth(line)
 		} else {
 			// Continuation lines carry the continuation prefix, which is empty
 			// unless the caller set one
-			actualLength = len([]rune(r.continuationPrefix)) + len(lineRunes)
+			actualLength = continuationLen + displayWidth(line)
 		}
 
 		// Calculate how many terminal lines this will take

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -217,7 +217,7 @@ func TestRendererPositionCursor(t *testing.T) {
 	lines := []string{"line1", "line2", "line3"}
 
 	// This mainly tests that the method doesn't crash
-	renderer.positionCursor(lines, 1, 2, 2)
+	renderer.positionCursor(lines, 1, 2, "$ ")
 
 	// Check that some output was written
 	result := output.String()
@@ -1011,6 +1011,104 @@ func TestRendererContinuationPrefix(t *testing.T) {
 		}
 		if prefixed != 3 {
 			t.Errorf("calculateRenderedLines() with a continuation prefix = %d, want 3", prefixed)
+		}
+	})
+}
+
+func TestRendererDisplayWidth(t *testing.T) {
+	t.Parallel()
+
+	// A rune is not a terminal cell. "データ> " is 5 runes but 8 columns, so a
+	// rune count moved the cursor three columns short of the character it was
+	// meant to sit on, and undercounted how many rows the input occupied.
+	cursorTests := []struct {
+		name   string
+		lines  []string
+		line   int
+		col    int
+		prefix string
+		want   string
+		why    string
+	}{
+		{
+			name:   "wide prefix",
+			lines:  []string{"ab", "cd"},
+			line:   0,
+			col:    2,
+			prefix: "データ> ",
+			want:   "\x1b[10C",
+			why:    "8 columns of prefix plus 2 of text, not 5 plus 2",
+		},
+		{
+			name:   "wide line content",
+			lines:  []string{"あい", "x"},
+			line:   0,
+			col:    2,
+			prefix: "$ ",
+			want:   "\x1b[6C",
+			why:    "2 columns of prefix plus 4 of text, not 2 plus 2",
+		},
+		{
+			name:   "single line moves back by cells",
+			lines:  []string{"あいう"},
+			line:   0,
+			col:    1,
+			prefix: "$ ",
+			want:   "\x1b[4D",
+			why:    "the two remaining wide runes are 4 columns, not 2",
+		},
+		{
+			// "e" followed by U+0301 is 2 runes and 1 column.
+			name:   "combining mark adds no column",
+			lines:  []string{"e\u0301x", "y"},
+			line:   0,
+			col:    3,
+			prefix: "$ ",
+			want:   "\x1b[4C",
+			why:    "2 columns of prefix plus 2 of text",
+		},
+	}
+
+	for _, tt := range cursorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			renderer := newRenderer(&output, ThemeDefault, nil)
+			renderer.positionCursor(tt.lines, tt.line, tt.col, tt.prefix)
+
+			if got := output.String(); !strings.Contains(got, tt.want) {
+				t.Errorf("positionCursor() wrote %q, want it to contain %q (%s)", got, tt.want, tt.why)
+			}
+		})
+	}
+
+	t.Run("wrapped-line count measures cells", func(t *testing.T) {
+		t.Parallel()
+
+		var output bytes.Buffer
+		renderer := newRenderer(&output, ThemeDefault, nil)
+
+		// 41 wide runes are 82 columns, which does not fit an 80-column row.
+		if got := renderer.calculateRenderedLines("", strings.Repeat("あ", 41)); got != 2 {
+			t.Errorf("calculateRenderedLines() = %d, want 2 (82 columns wraps at 80)", got)
+		}
+		// A prefix of 8 columns plus 76 of text is 84, also two rows.
+		if got := renderer.calculateRenderedLines("データ> ", strings.Repeat("x", 76)); got != 2 {
+			t.Errorf("calculateRenderedLines() = %d, want 2 (84 columns wraps at 80)", got)
+		}
+	})
+
+	t.Run("continuation prefix is measured in cells too", func(t *testing.T) {
+		t.Parallel()
+
+		var output bytes.Buffer
+		renderer := newRenderer(&output, ThemeDefault, nil)
+		renderer.setContinuationPrefix("続き> ")
+
+		renderer.positionCursor([]string{"a", "bc"}, 1, 2, "$ ")
+		if got := output.String(); !strings.Contains(got, "\x1b[8C") {
+			t.Errorf("positionCursor() wrote %q, want it to contain %q (6 columns of prefix plus 2 of text)", got, "\x1b[8C")
 		}
 	})
 }


### PR DESCRIPTION
Closes #19.

## Summary

The renderer counted runes where it needed terminal cells. `"データ> "` is 5 runes and 8 columns, an emoji is 1 rune and 2 columns, and a combining mark is a rune that occupies none. A CJK or emoji prompt prefix therefore left the cursor several columns away from the character it was meant to sit on, and a line that wrapped at the terminal edge was counted as fitting, so `clearPreviousLines` cleared too few rows and left stale text on screen.

The multi-line branch of `positionCursor` was worse than a rune count: it moved right by the cursor's rune index and ignored the width of the text before it entirely, so any wide character anywhere on the line moved the cursor to the wrong place.

## Changes

- `renderer.go`: a `displayWidth` helper over `go-runewidth`. `positionCursor` takes the prefix string rather than a precomputed rune count and writes every distance as the display width of the text it spans — the prefix for that line (prompt prefix on the first, continuation prefix on the rest) plus the text before the cursor, and, on a single line, the text after it. `calculateRenderedLines` measures both prefixes and each line in cells.
- `renderer_test.go`: `TestRendererDisplayWidth` pins the escape sequences for a wide prefix, wide line content, a combining mark, a single-line backward move, a wide continuation prefix, and the wrapped-row count at exactly the 80-column boundary.
- `go.mod`: `github.com/mattn/go-runewidth` becomes a direct dependency.

## Design Decisions

`go-runewidth` rather than a hand-rolled East Asian Width table: it already tracks the Unicode data, handles ambiguous-width and emoji sequences, and is the same author as the `go-colorable` and `go-tty` this package already depends on.

`positionCursor` now takes `prefix string` instead of `prefixLen int`. It needs the continuation prefix for lines after the first, which it reads from the renderer, and taking the string keeps both prefixes measured the same way in one place rather than leaving the caller to pick a measure.

Rune indexes are still how the cursor is tracked in the buffer; only the distances written to the terminal changed. `findCursorPosition` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal cursor positioning for wide characters, such as Japanese text, and combining marks.
  - Fixed line-wrapping calculations when prompts or continuation prefixes contain characters with varying display widths.
  - Prevented stale text from remaining after screen redraws by ensuring rendered content is cleared accurately.
- **Tests**
  - Added coverage for cursor movement and wrapping with wide and zero-width characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->