### PR TITLE
fix: stop the prompt erasing the last line printed before it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **The prompt erased the last line of whatever was printed before it (PR [#28](https://github.com/nao1215/prompt/pull/28))**: the renderer remembers the block it drew so it can erase it on the next keystroke, and it still remembered it after the line was submitted. By then that block belongs to the finished line, and the application has printed its own output underneath it, so the next prompt moved up into that output and erased from there. One row up per row the entry had occupied: a single-line entry erased nothing extra, while a statement typed across a continuation line ate the last line of the result printed for it — a table lost its bottom border. The renderer now forgets the block when a line ends, so a fresh prompt erases only the line it is on.
+
 ## [0.0.16] - 2026-08-05
 
 ### Added

--- a/prompt.go
+++ b/prompt.go
@@ -748,9 +748,12 @@ func (p *Prompt) RunWithContext(ctx context.Context) (string, error) {
 		}
 	}()
 
-	// Initialize buffer and display
+	// Initialize buffer and display. The renderer starts each line knowing
+	// nothing about what is on screen: the previous line is finished, and
+	// whatever the application printed after it is not this prompt's to erase.
 	p.buffer = []rune{}
 	p.cursor = 0
+	p.renderer.forgetBlock()
 	if err := p.render(); err != nil {
 		return "", fmt.Errorf("failed to render prompt: %w", err)
 	}

--- a/renderer.go
+++ b/renderer.go
@@ -321,7 +321,21 @@ func (r *renderer) renderSuggestionsWithOffset(_, _ string, _ int, suggestions [
 // prompt at the top. It implements the Ctrl+L clear-screen behavior.
 func (r *renderer) clearScreen() {
 	fmt.Fprint(r.output, "\x1b[H\x1b[2J\x1b[3J")
+	r.forgetBlock()
+}
+
+// forgetBlock drops what the renderer remembers about the block on screen, so
+// the next render erases only the line it is on.
+//
+// It is called when a line ends and when the screen is cleared. What was drawn
+// belongs to the finished line then, and the application prints its own output
+// underneath it before the next prompt appears. A render that still moved up to
+// erase "its" block would erase that output instead: after an entry that
+// occupied two rows, the first row erased was the last row the application had
+// printed, so a result table lost its bottom border.
+func (r *renderer) forgetBlock() {
 	r.lastLines = 1
+	r.lastCursorRow = 0
 	r.suggestionsActive = false
 }
 

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -2,7 +2,9 @@ package prompt
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -1267,5 +1269,104 @@ func TestRendererPositionsTheCursorOnTheWrappedRowItBelongsTo(t *testing.T) {
 	}
 	if !strings.Contains(got, "\r\x1b[12C") {
 		t.Errorf("render() wrote %q, want it to place the cursor at column 12 of that row", got)
+	}
+}
+
+// cursorUpSequence matches the ANSI "move up" the renderer emits when it erases
+// a block it drew across several rows.
+var cursorUpSequence = regexp.MustCompile(`\x1b\[\d*A`)
+
+// TestRendererForgetBlockStopsErasingFinishedOutput covers what happens between
+// two prompts. Once a line is submitted, whatever the renderer drew belongs to
+// the finished line, and the application prints its own output below it. A
+// render that still moved up to erase "its" block reached into that output
+// instead: after a two-line entry, the first row it erased was the last row the
+// application had printed, so a result table lost its bottom border.
+func TestRendererForgetBlockStopsErasingFinishedOutput(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	r := newRenderer(&output, ThemeDefault, nil)
+
+	// A two-line entry, as a statement typed across a continuation line.
+	if err := r.render("$ ", "SELECT 1\n;", 10); err != nil {
+		t.Fatalf("first render failed: %v", err)
+	}
+
+	// The line is submitted and the application prints its result. The renderer
+	// is told the block is no longer its to erase.
+	r.forgetBlock()
+
+	output.Reset()
+	if err := r.render("$ ", "", 0); err != nil {
+		t.Fatalf("render after the submission failed: %v", err)
+	}
+
+	if got := output.String(); cursorUpSequence.MatchString(got) {
+		t.Errorf("the prompt after a submission moved up into finished output: %q", got)
+	}
+}
+
+// TestRendererStillErasesItsOwnBlockWhileEditing is the other half: within one
+// line, a multi-row block must still be erased on every keystroke, or the
+// previous draw stays on screen underneath the new one.
+func TestRendererStillErasesItsOwnBlockWhileEditing(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	r := newRenderer(&output, ThemeDefault, nil)
+
+	if err := r.render("$ ", "SELECT 1\n;", 10); err != nil {
+		t.Fatalf("first render failed: %v", err)
+	}
+
+	output.Reset()
+	if err := r.render("$ ", "SELECT 1\n;;", 11); err != nil {
+		t.Fatalf("second render failed: %v", err)
+	}
+
+	if got := output.String(); !cursorUpSequence.MatchString(got) {
+		t.Errorf("editing a two-row entry did not erase the row above: %q", got)
+	}
+}
+
+// TestPromptDoesNotEraseOutputPrintedBetweenRuns drives the whole read loop the
+// way a REPL does: a statement typed across two lines, then the application's
+// output, then the next prompt. The second Run must not move the cursor up —
+// everything above it belongs to the finished line and to the output.
+func TestPromptDoesNotEraseOutputPrintedBetweenRuns(t *testing.T) {
+	t.Parallel()
+
+	// "SELECT 1" is incomplete, so Enter opens a continuation line; ";" completes
+	// it. The second line is then submitted on its own.
+	mock := newMockTerminal("SELECT 1\r;\rnext;\r")
+	var output bytes.Buffer
+	config := Config{
+		Prefix:     "$ ",
+		Multiline:  true,
+		IsComplete: func(input string) bool { return strings.HasSuffix(strings.TrimSpace(input), ";") },
+	}
+	p := &Prompt{
+		config:   config,
+		terminal: mock,
+		keyMap:   NewDefaultKeyMap(),
+		output:   &output,
+		renderer: newRenderer(&output, ThemeDefault, mock),
+	}
+
+	if got, err := p.RunWithContext(context.Background()); err != nil || got != "SELECT 1\n;" {
+		t.Fatalf("first Run = %q, %v; want the two-line statement", got, err)
+	}
+
+	// What the application prints between prompts.
+	fmt.Fprint(&output, "+---+\r\n| 1 |\r\n+---+\r\n")
+
+	output.Reset()
+	if _, err := p.RunWithContext(context.Background()); err != nil {
+		t.Fatalf("second Run returned error: %v", err)
+	}
+
+	if got := output.String(); cursorUpSequence.MatchString(got) {
+		t.Errorf("the prompt after a two-line statement moved up into the printed result: %q", got)
 	}
 }


### PR DESCRIPTION
## The report

In a shell built on this library, the same query showed a different result depending on how it was typed:

```text
sqly:~(table)$ SELECT * FROM identifier
   ...> ;

+----+-----------+
| id | position  |
+----+-----------+
|  1 | developrt |
|  2 | manager   |
|  3 | neet      |
sqly:~(table)$                              <- the bottom border is gone

sqly:~(table)$ SELECT * FROM identifier;

+----+-----------+
| id | position  |
+----+-----------+
|  1 | developrt |
|  2 | manager   |
|  3 | neet      |
+----+-----------+                          <- typed on one line, it is there
sqly:~(table)$
```

## Why

The renderer remembers the block it drew so the next keystroke can erase it, and it still remembered it after the line was submitted. By then that block belongs to the finished line, and the application has printed its own output underneath it. The next prompt therefore moved up into that output and erased from there:

```
+------------+\r\n   <- the last line the application printed
\x1b[1A               <- up one row, into it
\r\x1b[0J             <- erase to the end of the screen
```

The damage is one row per row the entry occupied. A single-line entry moves up none, which is why only the multi-line case looked broken; a two-line entry ate exactly one line, the last one printed.

## The fix

The renderer forgets the block when a line ends, so a fresh prompt erases only the line it is on. Erasing within a line is untouched: a multi-row entry still clears its own rows on every keystroke, which is what keeps an edit from leaving its previous draw on screen.

## Tests

Three, all failing before the change: a renderer that has drawn a two-row block emits no cursor-up on the next render after the block is released; a renderer editing a two-row block still does emit one; and the whole read loop — a two-line statement, then output printed between prompts, then the next `Run` — writes no cursor-up sequence. The last one reproduces the report exactly and fails with the `\x1b[1A\r\x1b[0J` above.